### PR TITLE
feat: add users collection

### DIFF
--- a/payload.config.ts
+++ b/payload.config.ts
@@ -1,6 +1,7 @@
 import { buildConfig } from 'payload/config';
 import dotenv from 'dotenv';
 import { Pool } from 'pg';
+import Users from './src/collections/Users';
 
 dotenv.config();
 
@@ -8,8 +9,12 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
+// Ensure pgcrypto extension for field-level encryption
+pool.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+
 export default buildConfig({
   serverURL: 'http://localhost:3000',
+  collections: [Users],
   globals: [],
   db: {
     pool,

--- a/src/collections/Users.ts
+++ b/src/collections/Users.ts
@@ -1,0 +1,131 @@
+import type { CollectionConfig, FieldHook } from 'payload/types';
+import { Pool } from 'pg';
+import { randomUUID } from 'crypto';
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const ENCRYPTION_KEY = process.env.DB_ENCRYPTION_KEY || 'default_secret';
+
+const encrypt: FieldHook = async ({ value }) => {
+  if (typeof value !== 'string') return value;
+  const res = await pool.query(
+    "SELECT encode(pgp_sym_encrypt($1, $2), 'base64') AS enc",
+    [value, ENCRYPTION_KEY],
+  );
+  return res.rows[0]?.enc;
+};
+
+const decrypt: FieldHook = async ({ value }) => {
+  if (typeof value !== 'string') return value;
+  const res = await pool.query(
+    "SELECT pgp_sym_decrypt(decode($1, 'base64'), $2) AS dec",
+    [value, ENCRYPTION_KEY],
+  );
+  return res.rows[0]?.dec;
+};
+
+const bcryptRegex = /^\$2[aby]\$\d{2}\$[./0-9A-Za-z]{53}$/;
+const argon2idRegex = /^\$argon2id\$v=\d+\$m=\d+,t=\d+,p=\d+\$[A-Za-z0-9+/]+=*\$[A-Za-z0-9+/]+=*$/;
+
+const Users: CollectionConfig = {
+  slug: 'users',
+  admin: { useAsTitle: 'username' },
+  timestamps: true,
+  fields: [
+    {
+      name: 'id',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      defaultValue: () => randomUUID(),
+    },
+    {
+      name: 'walletAddress',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      validate: (val) =>
+        /^0x[a-fA-F0-9]{40}$/.test(val)
+          ? true
+          : 'Invalid wallet address format',
+    },
+    {
+      name: 'email',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      validate: (val) =>
+        /^\S+@\S+\.\S+$/.test(val)
+          ? true
+          : 'Invalid email format',
+      hooks: {
+        beforeChange: [encrypt],
+        afterRead: [decrypt],
+      },
+    },
+    {
+      name: 'passwordHash',
+      type: 'text',
+      required: true,
+      validate: (val) =>
+        bcryptRegex.test(val) || argon2idRegex.test(val)
+          ? true
+          : 'Password hash must be bcrypt or argon2id',
+      hooks: {
+        beforeChange: [encrypt],
+        afterRead: [decrypt],
+      },
+    },
+    {
+      name: 'username',
+      type: 'text',
+      required: true,
+      unique: true,
+      index: true,
+      validate: (val) =>
+        typeof val === 'string' && val.length >= 3 && val.length <= 30
+          ? true
+          : 'Username must be 3-30 characters',
+    },
+    {
+      name: 'avatar',
+      type: 'text',
+    },
+    {
+      name: 'bio',
+      type: 'textarea',
+    },
+    {
+      name: 'role',
+      type: 'select',
+      options: [
+        { label: 'User', value: 'user' },
+        { label: 'Admin', value: 'admin' },
+      ],
+      defaultValue: 'user',
+    },
+    {
+      name: 'premiumTier',
+      type: 'number',
+    },
+    {
+      name: 'subscriptionUntil',
+      type: 'date',
+    },
+    {
+      name: 'settings',
+      type: 'json',
+    },
+    {
+      name: 'deletedAt',
+      type: 'date',
+    },
+  ],
+};
+
+export default Users;


### PR DESCRIPTION
## Summary
- add Users collection with validation and pgcrypto-backed encryption
- enable pgcrypto extension and register Users collection

## Testing
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68910aa79f24832e8dd5fc8926998e3a