### PR TITLE
Implement user soft delete and cleanup CronJob

### DIFF
--- a/k8s/delete-expired-users-cronjob.yaml
+++ b/k8s/delete-expired-users-cronjob.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: delete-expired-users
+spec:
+  schedule: "0 0 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: delete-expired-users
+              image: your-app-image
+              command: ["node", "/app/dist/scripts/deleteExpiredUsers.js"]
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: app-env
+                      key: DATABASE_URL
+          restartPolicy: OnFailure

--- a/src/scripts/deleteExpiredUsers.ts
+++ b/src/scripts/deleteExpiredUsers.ts
@@ -1,0 +1,20 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const run = async () => {
+  await pool.query(
+    'DELETE FROM users WHERE "deletedAt" IS NOT NULL AND "deletedAt" < NOW() - INTERVAL \'30 days\''
+  );
+  await pool.end();
+};
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- support deleting the current user by wiping PII and marking `deletedAt`
- cronjob manifest to purge soft-deleted users after 30 days

## Testing
- `pnpm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68912381d148832e8981be0e1dc368db